### PR TITLE
Weird bug due to autosaving only part of the state

### DIFF
--- a/editor/static/scripts/state_handler.js
+++ b/editor/static/scripts/state_handler.js
@@ -57,6 +57,9 @@ async function loadState() {
                 states = data.states;
                 setLayout(data.layout);
                 setAllSettings(data.settings);
+                for (let i = 0; i !== states.length; ++i) {
+                    states[i] = jQuery.extend({}, base_state, states[i]);
+                }
             }
         });
 }


### PR DESCRIPTION
In #46 , I added a optimization that made saving the state of the client faster, by making saveState() save only those parts of the state that could change frequently. However, if you opened a file and then refreshed the client _without running the opened file_, it would cause a crash.

This is needed to complete #41.