### PR TITLE
Fixed a bug with the debugging of macros

### DIFF
--- a/editor/special_forms.py
+++ b/editor/special_forms.py
@@ -56,8 +56,7 @@ class ProcedureObject(Callable):
         gui_holder.expression.set_entries(
             [VisualExpression(expr, gui_holder.expression.display_value) for expr in body])
 
-        if self.evaluates_operands:
-            gui_holder.apply()
+        gui_holder.apply()
 
         for i, expression in enumerate(body):
             out = evaluate(expression,


### PR DESCRIPTION
Try debugging
```
(define-macro (f x) (car x))
(f (+ 1 2))
```
before and after the PR.