### PR TITLE
Make test cases warn if debugging before first run

### DIFF
--- a/editor/static/scripts/state_handler.js
+++ b/editor/static/scripts/state_handler.js
@@ -29,7 +29,7 @@ let base_state = {
     tests_open: false,
 
     active_code: "",
-    up_to_date: true,
+    up_to_date: false,
 
     test_results: undefined,
 


### PR DESCRIPTION
Before, you could view a case and hit "Debug" to get a blank page with no warning. This fixes that.