### PR TITLE
Made it complain at you when you stop the editor process.

### DIFF
--- a/editor/local_server.py
+++ b/editor/local_server.py
@@ -269,7 +269,8 @@ def instant(code, global_frame_id):
 
 def exit_handler(signal, frame):
     print(" - Ctrl+C pressed")
-    print("Shutting down server - all unsaved work will be lost")
+    print("Shutting down server - all unsaved work may be lost")
+    print("Remember that you should run python ok in a separate terminal window, to avoid stopping the editor process.")
     thread_state.cancel()
     sys.exit(0)
 

--- a/editor/static/index.html
+++ b/editor/static/index.html
@@ -88,7 +88,7 @@
                     A long-running operation is currently in progress.
                 </p>
                 <p>
-                    If your program has entered an infinite loop, open the terminal that you used to start the IDE
+                    If the editor isn't responding, open the terminal that you used to start the IDE
                     (where you ran <code>python editor</code>) and stop the process by pressing <kbd>Ctrl</kbd> +
                     <kbd>C</kbd>.
                 </p>
@@ -172,8 +172,36 @@
                     <span class="input-group-text">.scm</span>
                   </div>
                 </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-success" data-dismiss="modal" id="newFileButton">Create</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="disconnectedModal" tabindex="-1" role="dialog" data-backdrop="static"
+     aria-labelledby="disconnectedModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="disconnectedModalLabel">Process Disconnected</h5>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Warning! The <code>editor</code> process is no longer responding to queries from the front end. You have likely stopped the process in the terminal.
+                <p>
+                    Run <code>python editor -nb</code> in a terminal, then reconnect.
+                </p>
+                <p>
+                    Remember to run `python ok` (to unlock or submit tests) in a <b>separate</b> terminal window, to keep the editor session alive.
+                </p>
+            </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-success" data-dismiss="modal" id="newFileButton">Create</button>
+                <button type="button" id="reconnect-button" data-toggle="tooltip"
+                            title="Reconnect to the Scheme process."
+                            class="btn btn-primary"
+                            data-dismiss="modal">Reconnect</button>
             </div>
         </div>
     </div>

--- a/editor/static/index.html
+++ b/editor/static/index.html
@@ -189,12 +189,12 @@
             </div>
             <div class="modal-body">
                 <p>
-                    Warning! The <code>editor</code> process is no longer responding to queries from the front end. You have likely stopped the process in the terminal.
+                    Warning! The <code>editor</code> process is no longer responding to queries from the front end. <b>You have likely stopped the process in the terminal.</b>
                 <p>
                     Run <code>python editor -nb</code> in a terminal, then reconnect.
                 </p>
                 <p>
-                    Remember to run `python ok` (to unlock or submit tests) in a <b>separate</b> terminal window, to keep the editor session alive.
+                    Remember to run <code>python ok</code> (to unlock or submit tests) in a <b>separate</b> terminal window, so that you don't have to stop the editor process.
                 </p>
             </div>
             <div class="modal-footer">

--- a/editor/static/scripts/editor.js
+++ b/editor/static/scripts/editor.js
@@ -190,7 +190,10 @@ function register(layout) {
                 } else {
                     alert("Save error - try copying code from editor to a file manually");
                 }
-            });
+            }).fail(() => {
+                    $("#disconnectedModal").modal("show");
+                }
+            );
         }
 
         async function run() {


### PR DESCRIPTION
Title. A modal will pop up if the save() AJAX fails - since save() is called every 5 seconds anyway if the user is active, a failure will be detected quickly.

Motivated by a student in OH who though her code was failing the tests because clicking "Test" did nothing, but it was just not updating as the `editor` process was stopped.