### PR TITLE
Automatic Python 3.5 transpilation

### DIFF
--- a/editor/local_server.py
+++ b/editor/local_server.py
@@ -168,7 +168,7 @@ class Handler(server.BaseHTTPRequestHandler):
 
         elif path == "/save_state":
             global state
-            for key, val in json.loads(data[b"state"][0]).items():
+            for key, val in json.loads(data[b"state"][0].decode("utf-8")).items():
                 if key == "states":
                     if "states" not in state:
                         state["states"] = val

--- a/editor/local_server.py
+++ b/editor/local_server.py
@@ -289,7 +289,7 @@ def start(file_args, port, open_browser):
     PORT = port
     print(f"http://localhost:{PORT}")
     socketserver.TCPServer.allow_reuse_address = True
-    with ThreadedHTTPServer(("localhost", PORT), Handler) as httpd:
-        if open_browser:
-            webbrowser.open(f"http://localhost:{PORT}", new=0, autoraise=True)
-        httpd.serve_forever()
+    httpd = ThreadedHTTPServer(("localhost", PORT), Handler)
+    if open_browser:
+        webbrowser.open(f"http://localhost:{PORT}", new=0, autoraise=True)
+    httpd.serve_forever()

--- a/editor/log.py
+++ b/editor/log.py
@@ -100,13 +100,6 @@ class Root:
         cls.root = root
 
 
-def silence(*args): pass
-
-
-# def print_announce(message, local, root):
-#     print(f"{message:10}: {repr(local):50} {repr(root):20}")
-
-
 def limited(f):
     def g(*args, **kwargs):
         if not logger.log_op() and not kwargs.get("force", False):

--- a/editor/log.py
+++ b/editor/log.py
@@ -103,8 +103,8 @@ class Root:
 def silence(*args): pass
 
 
-def print_announce(message, local, root):
-    print(f"{message:10}: {repr(local):50} {repr(root):20}")
+# def print_announce(message, local, root):
+#     print(f"{message:10}: {repr(local):50} {repr(root):20}")
 
 
 def limited(f):

--- a/editor/log.py
+++ b/editor/log.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum
 from typing import List, Union, Dict, Tuple, TYPE_CHECKING
 
 from datamodel import Expression, ValueHolder, Pair, Nil, Symbol, Undefined, Promise, NilType, UndefinedType
@@ -14,10 +14,10 @@ OP_LIMIT = 25000
 
 
 class HolderState(Enum):
-    UNEVALUATED = auto()
-    EVALUATING = auto()
-    EVALUATED = auto()
-    APPLYING = auto()
+    UNEVALUATED = 1
+    EVALUATING = 2
+    EVALUATED = 3
+    APPLYING = 4
 
 
 class VisualExpression:

--- a/editor/ok_interface.py
+++ b/editor/ok_interface.py
@@ -17,13 +17,6 @@ FAILURE_SETUP_HEADER = '''; There was an error in running the setup code (probab
 
 FAILURE_SETUP_FOOTER = "; Raw ok output over"
 
-##############
-# OKPY IMPORTS
-# noinspection PyUnresolvedReferences
-from client.api import assignment
-
-import logging
-
 
 class PrintCapture:
     def __init__(self):
@@ -206,6 +199,11 @@ def process_case(case):
 
 
 def run_tests():
+    # noinspection PyUnresolvedReferences
+    from client.api import assignment
+
+    import logging
+
     LOGGING_FORMAT = '%(levelname)s  | %(filename)s:%(lineno)d | %(message)s'
     logging.basicConfig(format=LOGGING_FORMAT)
     log = logging.getLogger('client')  # Get top-level logger

--- a/editor/strip_annotations
+++ b/editor/strip_annotations
@@ -1,8 +1,0 @@
-py-backwards -i local_server.py -t 3.5 -o compiled -d
-
-#!/bin/bash
-mkdir -p stripped
-for file in *.py
-do
-  py-backwards -i "$file" -t 3.5 -o compiled -d
-done

--- a/editor/strip_annotations
+++ b/editor/strip_annotations
@@ -1,0 +1,8 @@
+py-backwards -i local_server.py -t 3.5 -o compiled -d
+
+#!/bin/bash
+mkdir -p stripped
+for file in *.py
+do
+  py-backwards -i "$file" -t 3.5 -o compiled -d
+done

--- a/strip_annotations
+++ b/strip_annotations
@@ -1,0 +1,6 @@
+#!/bin/bash
+cp -r ./editor ./compiled
+for file in editor/*.py
+do
+  py-backwards -i "$file" -t 3.5 -o compiled -d
+done


### PR DESCRIPTION
To use:
 - Run `bash strip_annotations`
 - Take the `compiled` folder, put it in the target directory, and rename it `editor`