### PR TITLE
Added a way to reformat files from the command line.

### DIFF
--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -4,23 +4,41 @@ import os
 
 import local_server
 import log
+from formatter import prettify
 
 parser = argparse.ArgumentParser(description="CS61A Scheme Editor - Spring 2019")
-parser.add_argument("-f", "--files",
-                    type=argparse.FileType('r+'),
-                    help="Scheme files to test",
-                    nargs='*')
-parser.add_argument("-nb", "--nobrowser",
-                    help="Do not open a new browser window.",
-                    action="store_true")
-parser.add_argument("-d", "--dotted",
-                    help="Enable dotted lists",
-                    action="store_true")
-parser.add_argument("-p", "--port",
-                    type=int,
-                    default=31415,
-                    help="Choose the port to access the editor")
+group = parser.add_mutually_exclusive_group()
+group.add_argument("-f", "--files",
+                   type=argparse.FileType('r+'),
+                   help="Scheme files to test",
+                   metavar="FILE",
+                   nargs='*')
+group.add_argument("-nb", "--nobrowser",
+                   help="Do not open a new browser window.",
+                   action="store_true")
+group.add_argument("-d", "--dotted",
+                   help="Enable dotted lists",
+                   action="store_true")
+group.add_argument("-p", "--port",
+                   type=int,
+                   default=31415,
+                   help="Choose the port to access the editor")
+group = parser.add_mutually_exclusive_group()
+group.add_argument("-r", "--reformat",
+                   type=argparse.FileType('a+'),
+                   help="Reformat input files",
+                   nargs=2,
+                   metavar=('SOURCE', 'DEST'))
 args = parser.parse_args()
+
+if args.reformat is not None:
+    source, dest = args.reformat
+    source.seek(0)
+    dest.truncate(0)
+    dest.write(prettify([source.read()]))
+    source.close()
+    dest.close()
+    exit()
 
 log.logger.dotted = args.dotted
 

--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -7,37 +7,44 @@ import log
 from formatter import prettify
 
 parser = argparse.ArgumentParser(description="CS61A Scheme Editor - Spring 2019")
-group = parser.add_mutually_exclusive_group()
-group.add_argument("-f", "--files",
-                   type=argparse.FileType('r+'),
-                   help="Scheme files to test",
-                   metavar="FILE",
-                   nargs='*')
-group.add_argument("-nb", "--nobrowser",
-                   help="Do not open a new browser window.",
-                   action="store_true")
-group.add_argument("-d", "--dotted",
-                   help="Enable dotted lists",
-                   action="store_true")
-group.add_argument("-p", "--port",
-                   type=int,
-                   default=31415,
-                   help="Choose the port to access the editor")
-group = parser.add_mutually_exclusive_group()
-group.add_argument("-r", "--reformat",
-                   type=argparse.FileType('a+'),
-                   help="Reformat input files",
-                   nargs=2,
-                   metavar=('SOURCE', 'DEST'))
+
+parser.add_argument("-f", "--files",
+                    type=argparse.FileType('r+'),
+                    help="Scheme files to test",
+                    metavar="FILE",
+                    nargs='*')
+parser.add_argument("-nb", "--nobrowser",
+                    help="Do not open a new browser window.",
+                    action="store_true")
+parser.add_argument("-d", "--dotted",
+                    help="Enable dotted lists",
+                    action="store_true")
+parser.add_argument("-p", "--port",
+                    type=int,
+                    default=31415,
+                    help="Choose the port to access the editor")
+parser.add_argument("-r", "--reformat",
+                    type=argparse.FileType('a+'),
+                    help="File to be reformatted.",
+                    metavar='FILE')
+parser.add_argument("-o", "--out",
+                    type=argparse.FileType('w+'),
+                    help="Write to separate output file")
 args = parser.parse_args()
 
 if args.reformat is not None:
-    source, dest = args.reformat
+    source = args.reformat
+    if args.out is not None:
+        dest = args.out
+    else:
+        dest = source
     source.seek(0)
+    prettified = prettify([source.read()])
     dest.truncate(0)
-    dest.write(prettify([source.read()]))
+    dest.write(prettified)
     source.close()
-    dest.close()
+    if args.out is not None:
+        dest.close()
     exit()
 
 log.logger.dotted = args.dotted

--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -12,7 +12,7 @@ def reformat_files(src, dest=None):
         dest = src
     with open(src) as src:
         formatted = prettify([src.read()])
-    with open(dest, "w+") as dest:
+    with open(dest, "w") as dest:
         dest.write(formatted + "\n")
     exit()
 

--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -6,6 +6,15 @@ import local_server
 import log
 from formatter import prettify
 
+def reformat_files(src, dest=None):
+    if dest is None:
+        dest = src
+    with open(src) as src:
+        formatted = prettify([src.read()])
+    with open(dest, "w+") as dest:
+        dest.write(formatted)
+    exit()
+
 parser = argparse.ArgumentParser(description="CS61A Scheme Editor - Spring 2019")
 
 parser.add_argument("-f", "--files",
@@ -24,28 +33,18 @@ parser.add_argument("-p", "--port",
                     default=31415,
                     help="Choose the port to access the editor")
 parser.add_argument("-r", "--reformat",
-                    type=argparse.FileType('a+'),
+                    type=str,
+                    nargs=*,
                     help="File to be reformatted.",
                     metavar='FILE')
 parser.add_argument("-o", "--out",
-                    type=argparse.FileType('w+'),
+                    type=str,
                     help="Write to separate output file")
 args = parser.parse_args()
 
 if args.reformat is not None:
-    source = args.reformat
-    if args.out is not None:
-        dest = args.out
-    else:
-        dest = source
-    source.seek(0)
-    prettified = prettify([source.read()])
-    dest.truncate(0)
-    dest.write(prettified)
-    source.close()
-    if args.out is not None:
-        dest.close()
-    exit()
+    reformat_files(*args.reformat)
+
 
 log.logger.dotted = args.dotted
 

--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -35,11 +35,8 @@ parser.add_argument("-p", "--port",
 parser.add_argument("-r", "--reformat",
                     type=str,
                     nargs="*",
-                    help="File to be reformatted.",
+                    help="Reformats file and writes to second argument, if exists, or in-place, otherwise..",
                     metavar='FILE')
-parser.add_argument("-o", "--out",
-                    type=str,
-                    help="Write to separate output file")
 args = parser.parse_args()
 
 if args.reformat is not None:

--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -34,7 +34,7 @@ parser.add_argument("-p", "--port",
                     help="Choose the port to access the editor")
 parser.add_argument("-r", "--reformat",
                     type=str,
-                    nargs=*,
+                    nargs="*",
                     help="File to be reformatted.",
                     metavar='FILE')
 parser.add_argument("-o", "--out",

--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -6,14 +6,16 @@ import local_server
 import log
 from formatter import prettify
 
+
 def reformat_files(src, dest=None):
     if dest is None:
         dest = src
     with open(src) as src:
         formatted = prettify([src.read()])
     with open(dest, "w+") as dest:
-        dest.write(formatted)
+        dest.write(formatted + "\n")
     exit()
+
 
 parser = argparse.ArgumentParser(description="CS61A Scheme Editor - Spring 2019")
 


### PR DESCRIPTION
Run
```
python editor --reformat SOURCE [-o OUT]
```
to reformat the file in `SOURCE` and write to `OUT` (optional, otherwise will just override `SOURCE`).