### PR TITLE
The disconnected modal will display on all ajax fails

### DIFF
--- a/editor/static/index.html
+++ b/editor/static/index.html
@@ -195,7 +195,7 @@
     </div>
 </div>
 
-<div class="modal fade" id="disconnectedModal" tabindex="-1" role="dialog" data-backdrop="static"
+<div class="modal fade" id="disconnectedModal" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false"
      aria-labelledby="disconnectedModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/editor/static/scripts/canceller.js
+++ b/editor/static/scripts/canceller.js
@@ -23,7 +23,7 @@ function register_cancel_button(btn) {
 }
 
 function refresh_button() {
-    if (button == undefined) {
+    if (button === undefined) {
         console.log("No button!");
         return;
     }

--- a/editor/static/scripts/editor.js
+++ b/editor/static/scripts/editor.js
@@ -232,10 +232,7 @@ function register(layout) {
                 } else {
                     alert("Save error - try copying code from editor to a file manually");
                 }
-            }).fail(() => {
-                    $("#disconnectedModal").modal("show");
-                }
-            );
+            })
         }
 
         async function run() {

--- a/editor/static/scripts/main.js
+++ b/editor/static/scripts/main.js
@@ -5,7 +5,7 @@ import * as settings from "./settings";
 import * as documentation from "./documentation";
 import * as keyboard_shortcuts from "./keyboard_shortcuts";
 import {loadState} from "./state_handler";
-import {request_update} from "./event_handler";
+import {end_slow, request_update} from "./event_handler";
 
 $(window).on("load", async function () {
     await loadState();
@@ -16,6 +16,11 @@ $(window).on("load", async function () {
     settings.init();
     documentation.init();
     keyboard_shortcuts.init();
+
+    $(document).ajaxError(() => {
+        end_slow();
+        $("#disconnectedModal").modal("show");
+    });
 
     request_update();
 });


### PR DESCRIPTION
Whereas before it would only display on a 5 second timer. So for instance you could save a file, stop the editor, press "Run", and it would appear as if the code was running in an infinite loop.

Now the correct error will appear.